### PR TITLE
Add simple test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Remove compiled binaries:
 make clean
 ```
 
+## Testing
+
+Run the minimal test suite with:
+
+```sh
+make test
+```
+
 ## License
 
 This project is licensed under the MIT license.

--- a/makefile
+++ b/makefile
@@ -15,3 +15,7 @@ $(TARGET): $(OBJS)
 
 clean:
 	rm -f $(TARGET) $(OBJS)
+
+
+test:
+	bash tests/test.sh

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+# Navigate to repository root
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Build the program
+make clean >/dev/null
+make >/dev/null
+
+# Run a short training loop
+./nnet >/dev/null
+
+# Verify model.bin is produced
+if [ ! -f model.bin ]; then
+  echo "model.bin was not created" >&2
+  exit 1
+fi
+
+echo "Test passed: model.bin exists"


### PR DESCRIPTION
## Summary
- add `tests/test.sh` for building and running the model
- expose test script via `make test`
- document tests in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840c27bf42c83289ba6404815991da3